### PR TITLE
Ingress Service 1.0.4

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
       - run: |
           dotnet tool install -g dotnet-format
           echo "$HOME/.dotnet/tools" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run dotnet format
         working-directory: ${{env.working-directory}}
         run: |
-          dotnet format --check platform-ingress.sln
+          dotnet format --verify-no-changes platform-ingress.sln

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 07-12-2021
+- Upgrade .NET runtime version
+- Update dependencies
+
 ## [1.0.3] - 06-02-2021
 - Versioning started
 - Import project from platform-core

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ensured through clever use of caches and document stores.
 
 [header1]: https://github.com/sensate-iot/SensateService/workflows/Docker/badge.svg "Docker Build"
 [header2]: https://github.com/sensate-iot/SensateService/workflows/Format%20check/badge.svg ".NET format"
-[header3]: https://img.shields.io/badge/version-v1.1.0-informational "Sensate IoT version"
+[header3]: https://img.shields.io/badge/version-v1.0.4-informational "Sensate IoT version"
 
 ## Sensor communication
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,6 @@ be answered, and issues/bug reports will be instantly closed.
 | Version   | Supported          |
 | --------- | ------------------ |
 | 1.0.x     | :white_check_mark: |
-| 1.1.x     | :white_check_mark: |
 | < 1.0.0   | :x:                |
 
 ## Reporting a Vulnerability

--- a/SensateIoT.Platform.Ingress.Common/SensateIoT.Platform.Ingress.Common.csproj
+++ b/SensateIoT.Platform.Ingress.Common/SensateIoT.Platform.Ingress.Common.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="MQTTnet" Version="3.0.14" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="MQTTnet" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/SensateIoT.Platform.Ingress.DataAccess/SensateIoT.Platform.Ingress.DataAccess.csproj
+++ b/SensateIoT.Platform.Ingress.DataAccess/SensateIoT.Platform.Ingress.DataAccess.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
   </ItemGroup>
 
 </Project>

--- a/SensateIoT.Platform.Ingress.MqttService/Dockerfile
+++ b/SensateIoT.Platform.Ingress.MqttService/Dockerfile
@@ -5,14 +5,14 @@
 # @email  michel@michelmegens.net
 #
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 
 WORKDIR /build
 COPY . .
 RUN dotnet restore -r linux-x64 SensateIoT.Platform.Ingress.MqttService/SensateIoT.Platform.Ingress.MqttService.csproj
 RUN dotnet publish -c Release -o /build/binaries -r linux-x64 --no-restore --no-restore SensateIoT.Platform.Ingress.MqttService/SensateIoT.Platform.Ingress.MqttService.csproj
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 
 COPY --from=build-env /build/binaries /app
 WORKDIR /app

--- a/SensateIoT.Platform.Ingress.MqttService/SensateIoT.Platform.Ingress.MqttService.csproj
+++ b/SensateIoT.Platform.Ingress.MqttService/SensateIoT.Platform.Ingress.MqttService.csproj
@@ -4,21 +4,21 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
 	<ServerGarbageCollection>true</ServerGarbageCollection>
-	<Version>1.0.3</Version>
-	<AssemblyVersion>1.0.3.0</AssemblyVersion>
-	<FileVersion>1.0.3.0</FileVersion>
+	<Version>1.0.4</Version>
+	<AssemblyVersion>1.0.4.0</AssemblyVersion>
+	<FileVersion>1.0.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SensateIoT.Platform.Ingress.MqttService/SensateIoT.Platform.Ingress.MqttService.csproj
+++ b/SensateIoT.Platform.Ingress.MqttService/SensateIoT.Platform.Ingress.MqttService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<ServerGarbageCollection>true</ServerGarbageCollection>
 	<Version>1.0.3</Version>
 	<AssemblyVersion>1.0.3.0</AssemblyVersion>


### PR DESCRIPTION
Upgrade the .NET runtime version from .NET 5 to .NET 6.

## Description
The Platform Ingress service now targets the .NET 6 runtime, instead of .NET 5. The unit test project has also been updated in order to target this version of the .NET environment.

## Motivation and Context
Migrate away from older versions of .NET.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
